### PR TITLE
Support julia 1.5 (second try)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -66,7 +66,7 @@ jobs:
     name: Notify Slack Failure
     needs: test
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule'
+    if: always() && github.event_name == 'schedule'
     steps:
       - uses: technote-space/workflow-conclusion-action@v2
       - uses: voxmedia/github-action-slack-notify-build@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,9 +29,9 @@ jobs:
           - os: macOS-latest
             arch: x86
         include:
-          # Add a 1.3 job because that's what Invenia actually uses
+          # Add a 1.5 job because that's what Invenia actually uses
           - os: ubuntu-latest
-            version: 1.3
+            version: 1.5
             arch: x64
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/JuliaNightly.yml
+++ b/.github/workflows/JuliaNightly.yml
@@ -28,7 +28,7 @@ jobs:
           git config --global user.name Tester
           git config --global user.email te@st.er
       - uses: julia-actions/julia-runtest@latest
-         env:
+        env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - uses: julia-actions/julia-processcoverage@v1

--- a/Project.toml
+++ b/Project.toml
@@ -20,9 +20,9 @@ XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 
 [compat]
 AWSCore = "0.5, 0.6"
-AWSS3 = "0.6"
+AWSS3 = "0.8"
 EzXML = "0.7.3, 0.8, 0.9, 1"
-FilePathsBase = "0.6, 0.7, 0.8, 0.9"
+FilePathsBase = "0.9"
 HTTP = "0.8.4"
 MbedTLS = "0.6, 0.7, 1"
 Memento = "0.12.1, 0.13, 1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWSTools"
 uuid = "83bcdc74-1232-581c-948a-f29122bf8259"
 authors = ["Invenia Technical Computing"]
-version = "1.8.0"
+version = "1.9.0"
 
 [deps]
 AWSCore = "4f1ea46c-232b-54a6-9b17-cc2d0f3e6598"

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,5 @@
 status = [
-    "Julia 1.3 - ubuntu-latest - x64",
+    "Julia 1.5 - ubuntu-latest - x64",
     "Julia 1 - macOS-latest - x64",
     "Julia 1 - ubuntu-latest - x64",
     "Julia 1 - ubuntu-latest - x86",

--- a/test/S3.jl
+++ b/test/S3.jl
@@ -37,7 +37,7 @@ function compare(src_file::AbstractPath, dest_file::AbstractPath)
         @test isfile(src_file)
         @test isfile(dest_file)
         @test basename(dest_file) == basename(src_file)
-        @test size(dest_file) == size(src_file)
+        @test filesize(dest_file) == filesize(src_file)
         @test modified(dest_file) >= modified(src_file)
 
         # Test file contents are equal


### PR DESCRIPTION
_Original PR: https://github.com/JuliaCloud/AWSTools.jl/pull/7 (GitHub check stuck)_

Running on julia 1.5, the S3 Online test was failing with the following error:
```
Upload to S3: Test Failed at /eph/builds/9sBThsZk/0/invenia/AWSTools.jl/test/S3.jl:241
  Expression: isdir(parent(dest))
```

Looks like this was a bug in `isdir` in AWSS3 before it was fixed in 0.7.2 (https://github.com/JuliaCloud/AWSS3.jl/pull/96).

Therefore bumping the compat of AWSS3 to the latest 0.8 (which is only compatible with FilePathsBase 0.9, hence the trimming of versions for FilePathsBase).