### PR TITLE
Deprecate all S3 functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWSTools"
 uuid = "83bcdc74-1232-581c-948a-f29122bf8259"
 authors = ["Invenia Technical Computing"]
-version = "1.10.0"
+version = "1.10.1"
 
 [deps]
 AWSCore = "4f1ea46c-232b-54a6-9b17-cc2d0f3e6598"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -67,11 +67,3 @@ AWSTools.EC2.instance_metadata(::AbstractString)
 AWSTools.EC2.instance_availability_zone()
 AWSTools.EC2.instance_region()
 ```
-
-### S3
-
-#### Exported
-
-```@docs
-AWSTools.S3.upload
-```

--- a/src/S3.jl
+++ b/src/S3.jl
@@ -18,7 +18,12 @@ export S3Path, sync, upload
 
 # TODO: Remove the sync methods below as they are now pirating.
 @deprecate(
-    sync(src::AbstractString, dest::AbstractString; delete::Bool=false, config::AWSConfig=aws_config()),
+    sync(
+        src::AbstractString,
+        dest::AbstractString;
+        delete::Bool=false,
+        config::AWSConfig=aws_config(),
+    ),
     FilePathsBase.sync(Path(src), Path(dest); delete=delete),
 )
 

--- a/src/S3.jl
+++ b/src/S3.jl
@@ -2,45 +2,24 @@ __precompile__()
 module S3
 
 using AWSCore
-using AWSS3
+using AWSS3: AWSS3
 using Dates
 using FilePathsBase
-using Memento
-
-import FilePathsBase: sync
 
 export S3Path, sync, upload
 
-const logger = getlogger(@__MODULE__)
+@deprecate S3Path(args...) AWSS3.S3Path(args...)
+@deprecate upload(src::AbstractPath, dest::AWSS3.S3Path) Base.cp(src, dest)
 
-# Register the module level logger at runtime so that folks can access the logger via
-# `getlogger(MyModule)`. If this line is not included then the precompiled
-# `MyModule.logger` won't be registered at runtime.
-function __init__()
-    Memento.register(logger)
-end
-
-# Couple extra methods that should probably be included in AWSS3 at some point.
-"""
-    upload(src::AbstractPath, dest::S3Path)
-
-Uploads a local file to the s3 path specified by `dest`.
-"""
-upload
-
-const upload = Base.cp
-
-# Note: naming copied from Go SDK:
-# https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/s3-example-presigned-urls.html
-function presign(
-    path::S3Path,
-    duration::Period=Hour(1);
-    config::AWSConfig=aws_config(),
+@deprecate(
+    presign(path::AWSS3.S3Path, duration::Period=Hour(1); config::AWSConfig=aws_config()),
+    AWSS3.s3_sign_url(config, path.bucket, path.key, Dates.value(Second(duration))),
 )
-    AWSS3.s3_sign_url(config, path.bucket, path.key, Dates.value(Second(duration)))
-end
 
 # TODO: Remove the sync methods below as they are now pirating.
-@deprecate sync(src::AbstractString, dest::AbstractString; delete::Bool=false, config::AWSConfig=aws_config()) sync(Path(src), Path(dest); delete=delete)
+@deprecate(
+    sync(src::AbstractString, dest::AbstractString; delete::Bool=false, config::AWSConfig=aws_config()),
+    FilePathsBase.sync(Path(src), Path(dest); delete=delete),
+)
 
 end  # S3

--- a/test/S3.jl
+++ b/test/S3.jl
@@ -4,7 +4,7 @@ using UUIDs
 
 using AWSTools.CloudFormation: stack_output
 using AWSTools.S3: sync, upload
-using AWSS3: AWSS3, S3Path, s3_create_bucket, s3_put, s3_delete_bucket
+using AWSS3: AWSS3, s3_create_bucket, s3_put, s3_delete_bucket
 
 # Enables the running of the "batch" online tests. e.g ONLINE=batch
 const ONLINE = strip.(split(get(ENV, "ONLINE", ""), r"\s*,\s*"))
@@ -78,9 +78,8 @@ end
     end
 
     @testset "Syncing" begin
-        @testset "Sync two local directories" begin
-            # Create files to sync
-            src = mktmpdir()
+        # Create files to sync
+        mktmpdir() do src
             src_file = join(src, "file1")
             write(src_file, "Hello World!")
 
@@ -95,431 +94,87 @@ end
             write(src_folder2_file, "Test")
 
             # Sync files
-            dest = mktmpdir()
-            @test isdir(dest)
-            sync(src, dest)
+            mktmpdir() do dest
+                @test isdir(dest)
+                @test_deprecated sync(string(src), string(dest))
 
-            # Test directories are the same
-            compare_dir(src, dest)
-
-            # Get paths of new files
-            dest_file = join(dest, "file1")
-            dest_file_mtime = modified(dest_file)
-            dest_folder = join(dest, basename(src_folder))
-            dest_folder_file = join(dest_folder, "file2")
-            dest_folder2 = join(dest_folder, basename(src_folder2))
-            dest_folder2_file = join(dest_folder2, "file3")
-
-            # Test that contents get copied over and size is equal
-            compare(src_file, dest_file)
-            compare(src_folder_file, dest_folder_file)
-            compare(src_folder2_file, dest_folder2_file)
-
-            compare_dir(src_folder, dest_folder)
-            compare_dir(src_folder2, dest_folder2)
-
-            @testset "Sync modified dest file" begin
-                # Modify a file in dest
-                write(dest_folder_file, "Modified in dest.")
-
-                # Syncing overwrites the newer file in dest because it is of different size
-                sync(src, dest)
-                compare(src_folder_file, dest_folder_file)
-            end
-
-            @testset "Sync modified src file" begin
-                 # Modify a file in src
-                write(src_folder_file, "Modified in src.")
-
-                # Test that syncing overwrites the modified file in dest
-                sync(src, dest)
-                compare(src_folder_file, dest_folder_file)
-
-                # Test other files weren't updated
-                @test modified(dest_file) == dest_file_mtime
-            end
-
-            @testset "Sync newer dest file" begin
-                # This is the case because a newer file of the same size is usually the
-                # result of an uploaded file always having a newer last_modified time.
-
-                # Modify a file in dest
-                write(dest_folder_file, "Modified in dest")
-
-                # Test that syncing doesn't overwrite the newer file in dest
-                sync(src, dest)
-                @test read(dest_folder_file) != read(src_folder_file)
-            end
-
-            @testset "Sync incompatible types" begin
-                @test_throws ArgumentError sync(src, dest_folder_file)
-                @test_throws ArgumentError sync(src_folder_file, dest)
-            end
-
-            rm(src_file)
-
-            @testset "Sync deleted file with no delete flag" begin
-                # Syncing should not delete the file in the destination
-                sync(src, dest)
-                @test isfile(dest_file)
-            end
-
-            @testset "Sync deleted files with delete flag" begin
-                # Test that syncing deletes the file in dest
-                sync(src, dest; delete=true)
-                @test !isfile(dest_file)
-
-                rm(Path(src_folder2); recursive=true)
-
-                @test isfile(dest_folder2_file)
-                @test isdir(dest_folder2)
-
-                sync(src, dest; delete=true)
-
-                @test !isfile(dest_folder2_file)
-                @test !isdir(dest_folder2)
-                @test isdir(dest_folder)
-            end
-
-            @testset "Sync files" begin
-                @test !isfile(dest_file)
-
-                write(src_file, "Test")
-
-                sync(src_file, dest_file)
-
-                @test isfile(dest_file)
-                compare(src_file, dest_file)
-            end
-
-            @testset "Sync empty directory" begin
-                rm(src; recursive=true)
-
-                @test_throws ArgumentError sync(src, dest, delete=true)
-            end
-
-            @testset "Sync non existent directories" begin
-                isdir(src) && rm(src; recursive=true)
-                isdir(dest) && rm(dest; recursive=true)
-
-                # Test syncing creates non existent local directories
-                @test_throws ArgumentError sync(src, dest)
+                # Test directories are the same
+                compare_dir(src, dest)
             end
         end
+    end
 
-        if "S3" in ONLINE
-            @testset "Online" begin
-                @info "Running ONLINE S3 tests"
+    if "S3" in ONLINE
+        @testset "Online" begin
+            @info "Running ONLINE S3 tests"
 
-                # Create bucket for tests
-                test_run_id = string(uuid4())
-                s3_prefix = if TEST_BUCKET_AND_PREFIX === nothing
-                    bucket = string("awstools-s3-test-temp-", uuid4())
-                    @info "Creating S3 bucket $bucket"
-                    s3_create_bucket(bucket)
-                    "s3://$bucket/$test_run_id"
-                else
-                    "$TEST_BUCKET_AND_PREFIX/$test_run_id"
+            # Create bucket for tests
+            test_run_id = string(uuid4())
+            s3_prefix = if TEST_BUCKET_AND_PREFIX === nothing
+                bucket = string("awstools-s3-test-temp-", uuid4())
+                @info "Creating S3 bucket $bucket"
+                s3_create_bucket(bucket)
+                "s3://$bucket/$test_run_id"
+            else
+                "$TEST_BUCKET_AND_PREFIX/$test_run_id"
+            end
+
+            try
+                @testset "Upload to S3" begin
+                    dest = @test_deprecated S3Path("$s3_prefix/folder3/testfile")
+
+                    try
+                        mktemp() do src, stream
+                            write(stream, "Local file src")
+                            close(stream)
+
+                            @test !exists(dest)
+
+                            uploaded_file = @test_deprecated upload(Path(src), dest)
+                            @test isa(uploaded_file, S3Path)
+
+                            @test exists(dest)
+                            @test isfile(dest)
+                            @test isdir(parent(dest))
+                            @test read(dest, String) == "Local file src"
+                        end
+                    finally
+                        rm(dest; recursive=true)
+                    end
                 end
 
-                try
-                    @testset "Upload to S3" begin
-                        dest = S3Path("$s3_prefix/folder3/testfile")
 
-                        try
-                            mktemp() do src, stream
-                                write(stream, "Local file src")
-                                close(stream)
+                @testset "Download via presign" begin
+                    src = S3Path("$s3_prefix/presign/file")
+                    content = "presigned content"
+                    s3_put(src.bucket, src.key, content)
 
-                                @test !exists(dest)
-
-                                uploaded_file = upload(Path(src), dest)
-                                @test isa(uploaded_file, S3Path)
-
-                                @test exists(dest)
-                                @test isfile(dest)
-                                @test isdir(parent(dest))
-                                @test read(dest, String) == "Local file src"
-                            end
-                        finally
-                            rm(dest; recursive=true)
-                        end
+                    @testset "file" begin
+                        url = @test_deprecated AWSTools.S3.presign(src, Dates.Minute(1))
+                        r = HTTP.get(url)
+                        @test String(r.body) == content
                     end
+                end
 
-                    @testset "Download from S3" begin
-                        src = S3Path("$s3_prefix/folder4/testfile")
+            finally
+                # Clean up any files left in the test directory
+                rm(S3Path("$s3_prefix/"); recursive=true)
 
-                        try
-                            s3_put(src.bucket, src.key, "Remote content")
-
-                            @testset "Download to a directory" begin
-                                mktempdir() do dest_dir
-                                    dest = Path(dest_dir)
-
-                                    dest_file = download(src, dest)
-                                    @test isa(dest_file, AbstractPath)
-
-                                    @test exists(Path(dest_file))
-                                    @test read(dest_file, String) == "Remote content"
-                                end
-                            end
-
-                            @testset "Download to a local file" begin
-                                mktemp() do dest_file, stream
-                                    dest = Path(dest_file)
-                                    close(stream)
-
-                                    dest_file = download(src, dest)
-                                    @test isa(dest_file, AbstractPath)
-
-                                    @test dest_file == dest
-                                    @test read(dest, String) == "Remote content"
-                                end
-                            end
-
-                        finally
-                            rm(src; recursive=true)
-                        end
-                    end
-
-                    @testset "Download via presign" begin
-                        src = S3Path("$s3_prefix/presign/file")
-                        content = "presigned content"
-                        s3_put(src.bucket, src.key, content)
-
-                        @testset "file" begin
-                            url = AWSTools.S3.presign(src, Dates.Minute(1))
-                            r = HTTP.get(url)
-                            @test String(r.body) == content
-                        end
-
-                        @testset "directory" begin
-                            url = AWSTools.S3.presign(parent(src), Dates.Minute(1))
-                            r = HTTP.get(url, status_exception=false)
-                            @test r.status == 404
-                            @test occursin("The specified key does not exist.", String(r.body))
-                        end
-
-                        @testset "expired" begin
-                            url = AWSTools.S3.presign(src, Dates.Second(1))
-                            sleep(2)
-                            r = HTTP.get(url, status_exception=false)
-                            @test r.status == 403
-                            @test occursin("Request has expired", String(r.body))
-                        end
-                    end
-
-                    @testset "Sync S3 directories" begin
-                        bucket, key_prefix = bucket_and_key(s3_prefix)
-
-                        src_dir = S3Path("$s3_prefix/folder1/")
-                        dest_dir = S3Path("$s3_prefix/folder2/")
-
-                        # Directories should be empty, but just in case
-                        # delete any pre-existing objects in the s3 bucket directories
-                        rm(src_dir; recursive=true)
-                        rm(dest_dir; recursive=true)
-
-                        # Make the src S3 directory
-                        mkdir(src_dir; recursive=true)
-                        mkdir(dest_dir; recursive=true)
-
-                        # Note: using `lstrip` for when `key_prefix` is empty
-                        # We also include the "folder" objects in this list.
-                        s3_objects = [
-                            Dict(
-                                "Bucket" => bucket,
-                                "Key" => lstrip("$key_prefix/folder1/", '/'),
-                                "Content" => "",
-                            ),
-                            Dict(
-                                "Bucket" => bucket,
-                                "Key" => lstrip("$key_prefix/folder1/folder/", '/'),
-                                "Content" => "",
-                            ),
-                            Dict(
-                                "Bucket" => bucket,
-                                "Key" => lstrip("$key_prefix/folder1/file1", '/'),
-                                "Content" => "Hello World!",
-                            ),
-                            Dict(
-                                "Bucket" => bucket,
-                                "Key" => lstrip("$key_prefix/folder1/file2", '/'),
-                                "Content" => "",
-                            ),
-                            Dict(
-                                "Bucket" => bucket,
-                                "Key" => lstrip("$key_prefix/folder1/folder/file3", '/'),
-                                "Content" => "Test",
-                            ),
-                        ]
-
-                        # Set up the source s3 directory
-                        for object in s3_objects
-                            s3_put(object["Bucket"], object["Key"], object["Content"])
-                        end
-
-                        # Sync files passing in directories as strings
-                        sync(string(src_dir), string(dest_dir))
-
-                        src_files = collect(walkpath(src_dir))
-                        dest_files = collect(walkpath(dest_dir))
-
-                        # Test destination directory has expected files
-                        @test !isempty(dest_files)
-                        @test length(dest_files) == length(src_files)
-
-                        # Test directories are the same
-                        compare_dir(src_dir, dest_dir)
-
-                        # Test readdir only lists files and "dirs" within this S3 "dir"
-                        @test readdir(dest_dir) == ["file1", "file2", "folder/"]
-                        @test readdir(S3Path("$s3_prefix/")) == [
-                            "folder1/", "folder2/", "presign/"
-                        ]
-                        # Not including the ending `/` means this refers to an object and
-                        # not a directory prefix in S3
-                        @test_throws ArgumentError readdir(S3Path(s3_prefix))
-
-                        @testset "Sync modified dest file" begin
-                            # Modify a file in dest
-                            s3_put(
-                                dest_files[1].bucket,
-                                dest_files[1].key,
-                                "Modified in dest.",
-                            )
-
-                            # Syncing overwrites the newer file in dest because it is of
-                            # a different size
-                            sync(src_dir, dest_dir)
-
-                            # Test directories are the same
-                            compare_dir(src_dir, dest_dir)
-
-                            @test read(dest_files[1], String) == s3_objects[3]["Content"]
-                        end
-
-                        @testset "Sync modified src file" begin
-                            # Modify a file in src
-                            s3_objects[3]["Content"] = "Modified in src."
-                            s3_put(
-                                s3_objects[3]["Bucket"],
-                                s3_objects[3]["Key"],
-                                s3_objects[3]["Content"],
-                            )
-
-                            # Test that syncing overwrites the modified file in dest
-                            sync(src_dir, dest_dir)
-
-                            # Test directories are the same
-                            compare_dir(src_dir, dest_dir)
-
-                            @test read(dest_files[1], String) == s3_objects[3]["Content"]
-                        end
-
-                        @testset "Sync newer file in dest" begin
-                            # Modify a file in dest
-                            s3_put(
-                                dest_files[1].bucket,
-                                dest_files[1].key,
-                                "Modified in dest",
-                            )
-
-                            # Test that syncing doesn't overwrite the newer file in dest
-                            # This is the case because a newer file of the same size is
-                            # usually the result of an uploaded file always having a newer
-                            # last_modified time.
-                            sync(src_dir, dest_dir)
-
-                            file_contents = read(dest_files[1], String)
-                            @test file_contents != s3_objects[3]["Content"]
-                            @test file_contents ==  "Modified in dest"
-                        end
-
-                        @testset "Sync s3 bucket with object prefix" begin
-                            obj = s3_objects[3]
-                            file = "s3://" * join([obj["Bucket"], obj["Key"]], '/')
-
-                            @test startswith(file, "s3://")
-                            @test_throws ArgumentError sync(S3Path(file), dest_dir)
-                        end
-
-                        rm(src_files[1])
-
-                        @testset "Sync deleted file with no delete flag" begin
-                            sync(src_dir, dest_dir)
-
-                            # We collect the walkpath result because we want it to complete
-                            # before checking the length
-                            src_files = collect(walkpath(src_dir))
-                            dest_files = collect(walkpath(dest_dir))
-
-                            @test length(dest_files) == length(src_files) + 1
-                        end
-
-                        @testset "Sync deleted files with delete flag" begin
-                            # Test that syncing deletes the file in dest
-                            sync(src_dir, dest_dir; delete=true)
-
-                            # We collect the walkpath result because we want it to complete
-                            # before checking the length
-                            src_files = collect(walkpath(src_dir))
-                            dest_files = collect(walkpath(dest_dir))
-                            @test length(dest_files) == length(src_files)
-                        end
-
-                        @testset "Sync files" begin
-                            src_file = S3Path("$s3_prefix/folder1/file")
-                            dest_file = S3Path("$s3_prefix/folder2/file")
-
-                            # Modify file in src dir
-                            write(src_file, "Test modified file in source")
-
-                            # Test syncing individual files instead of directories
-                            sync(src_file, dest_file)
-
-                            # Test directories are the same
-                            compare_dir(src_dir, dest_dir)
-
-                            # Test destination file was modifies
-                            @test read(dest_file, String) == "Test modified file in source"
-                        end
-
-                        @testset "Sync non-existent directory" begin
-                            rm(src_dir; recursive=true)
-
-                            # Error because src folder doesn't exist
-                            @test_throws ArgumentError sync(src_dir, dest_dir; delete=true)
-
-                            src_files = collect(walkpath(src_dir))
-                            @test isempty(src_files)
-
-                            rm(dest_dir; recursive=true)
-                            dest_files = collect(walkpath(dest_dir))
-                            @test isempty(dest_files)
-                        end
-                    end
-
-                finally
-                    # Clean up any files left in the test directory
-                    rm(S3Path("$s3_prefix/"); recursive=true)
-
-                    # Delete bucket if it was explicitly created
-                    if TEST_BUCKET_AND_PREFIX === nothing
-                        s3_bucket_dir = replace(s3_prefix, r"^(s3://[^/]+).*$" => s"\1")
-                        bucket, key = bucket_and_key(s3_bucket_dir)
-                        @info "Deleting S3 bucket $bucket"
-                        rm(S3Path("s3://$bucket/"); recursive=true)
-                        s3_delete_bucket(bucket)
-                    end
+                # Delete bucket if it was explicitly created
+                if TEST_BUCKET_AND_PREFIX === nothing
+                    s3_bucket_dir = replace(s3_prefix, r"^(s3://[^/]+).*$" => s"\1")
+                    bucket, key = bucket_and_key(s3_bucket_dir)
+                    @info "Deleting S3 bucket $bucket"
+                    rm(S3Path("s3://$bucket/"); recursive=true)
+                    s3_delete_bucket(bucket)
                 end
             end
-        else
-            @warn """
-                Skipping AWSTools.S3 ONLINE tests. Set `ENV["ONLINE"] = "S3"` to run."
-                Can also optionally specify a test bucket name `ENV["TEST_BUCKET_AND_PREFIX"] = "s3://bucket/dir/"`.
-                If `TEST_BUCKET_AND_PREFIX` is not specified, a temporary bucket will be created, used, and then deleted.
-                """
         end
+    else
+        @warn """
+            Skipping AWSTools.S3 ONLINE tests. Set `ENV["ONLINE"] = "S3"` to run."
+            Can also optionally specify a test bucket name `ENV["TEST_BUCKET_AND_PREFIX"] = "s3://bucket/dir/"`.
+            If `TEST_BUCKET_AND_PREFIX` is not specified, a temporary bucket will be created, used, and then deleted.
+            """
     end
 end

--- a/test/S3.jl
+++ b/test/S3.jl
@@ -143,7 +143,6 @@ end
                     end
                 end
 
-
                 @testset "Download via presign" begin
                     src = S3Path("$s3_prefix/presign/file")
                     content = "presigned content"


### PR DESCRIPTION
Deprecates all the things in S3 and removes most of the tests in preparation for dropping the module.
Part of https://github.com/JuliaCloud/AWSTools.jl/issues/12.